### PR TITLE
Revert "tidy up definition of owner in funding"

### DIFF
--- a/funding/models.py
+++ b/funding/models.py
@@ -187,10 +187,7 @@ class FundingSource(Attribution):
             pi_group = Group.objects.get(name='funding_source_pi')
             pi_group.user_set.add(self.pi)
 
-        if self.pi.profile.institution.needs_funding_approval:
-            self.owner = self.pi
-        else:
-            self.owner = self.created_by
+        self.owner = self.pi
 
         self.pi_email = None
 

--- a/funding/models.py
+++ b/funding/models.py
@@ -187,7 +187,10 @@ class FundingSource(Attribution):
             pi_group = Group.objects.get(name='funding_source_pi')
             pi_group.user_set.add(self.pi)
 
-        self.owner = self.created_by
+        if self.pi.profile.institution.needs_funding_approval:
+            self.owner = self.pi
+        else:
+            self.owner = self.created_by
 
         self.pi_email = None
 


### PR DESCRIPTION
Reverts M4rkD/cogs3#2

Looks like we missed something—this causes a regression where users can now approve their own funding sources. The previous definition correctly prevents users approving their own projects, although it does leave edbennett#87 unresolved.