### PR TITLE
work around PI's name not being available when creating via funding workflow

### DIFF
--- a/funding/generate_docx.py
+++ b/funding/generate_docx.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 
 def create_funding_document(
-    funding_body, title, pi_firstname, pi_lastname, pi_department, receiver,
+    funding_body, title, pi_fullname, pi_department, receiver,
     template
 ):
     document = Document('templates/funding/document/' + template)
@@ -40,9 +40,7 @@ def create_funding_document(
     document.add_paragraph("")
     document.add_paragraph("")
     document.add_paragraph("______________________")
-    document.add_paragraph(
-        'Prof. {first} {last}'.format(first=pi_firstname, last=pi_lastname)
-    )
+    document.add_paragraph('Prof. {name}'.format(name=pi_fullname))
     if (pi_department):
         document.add_paragraph('{department}'.format(department=pi_department))
     document.add_paragraph("Swansea University")

--- a/funding/tests/test_generate_docx.py
+++ b/funding/tests/test_generate_docx.py
@@ -10,8 +10,7 @@ class create_funding_documentTest(TestCase):
         self.fixture = {
             'funding_body': 'FUNDINGBODY',
             'title': '"TITLE"',
-            'pi_firstname': 'PINAME',
-            'pi_lastname': 'PILASTNAME',
+            'pi_fullname': 'PINAME',
             'pi_department': 'PIDEPARTMENT',
             'receiver': 'RECEIVER',
         }

--- a/funding/views.py
+++ b/funding/views.py
@@ -35,8 +35,17 @@ class FundingSourceCreateView(SuccessMessageMixin, LoginRequiredMixin, generic.C
     def notify_pi(self, fundingsource):
         user_name = fundingsource.created_by.first_name + ' ' + fundingsource.created_by.last_name
         subject = _('{company_name} Attribution Request by {user}'.format(company_name=settings.COMPANY_NAME, user=user_name))
+
+        if fundingsource.pi.first_name:
+            email_addressee = fundingsource.pi.first_name
+            letter_from_line = ' '.join((fundingsource.pi.first_name,
+                                         fundingsource.pi.last_name))
+        else:
+            email_addressee = fundingsource.pi.email.split('@')[0]
+            letter_from_line = 'YOUR NAME HERE'
+
         context = {
-            'first_name': fundingsource.pi.first_name,
+            'first_name': email_addressee,
             'to': fundingsource.pi.email,
             'identifier': fundingsource.identifier,
             'title': fundingsource.title,
@@ -46,8 +55,7 @@ class FundingSourceCreateView(SuccessMessageMixin, LoginRequiredMixin, generic.C
         docx_file = create_funding_document(
             fundingsource.funding_body.name,
             fundingsource.title,
-            fundingsource.pi.first_name,
-            fundingsource.pi.last_name,
+            letter_from_line,
             fundingsource.pi.profile.shibbolethprofile.department,
             fundingsource.pi.profile.institution.funding_document_receiver,
             fundingsource.pi.profile.institution.funding_document_template,


### PR DESCRIPTION
fixes edbennett#104

* if the PI is already in the database, nothing changes from current behaviour
* if the PI is not in the database, the front half of their email address is used
  to address them in the email body, and placeholder text is used in the funding
  document