### PR TITLE
change RSE and systems allocations to more descriptive names

### DIFF
--- a/templates/project/allocation_detail.html
+++ b/templates/project/allocation_detail.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 {% load static %}
 {% load widget_tweaks %}
-{% block title %}{% trans "Allocation request details" %}{% endblock %}
+{% block title %}{% trans "Supercomputer access request details" %}{% endblock %}
 {% block content %}
 	<div class="my-3 px-3 pt-3 bg-white rounded box-shadow">
 		<div class="row">
 			<div class="col">
 				<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
-					<h4>{% trans "Allocation Request" %}</h4>
+					<h4>{% trans "Supercomputer Access Request" %}</h4>
 				</div>
 			</div>
 		</div>
@@ -44,7 +44,7 @@
 								<td>{{allocation.requirements_onboarding}}</td>
 							</tr>
 							<tr>
-								<th scope="row">{% trans "CPU time allocation in hours" %}</th>
+								<th scope="row">{% trans "Requested CPU time in hours" %}</th>
 								<td>{{allocation.allocation_cputime}}</td>
 							</tr>
 							<tr>

--- a/templates/project/application_detail.html
+++ b/templates/project/application_detail.html
@@ -130,7 +130,7 @@
                 </table>
 
                 {% if request.user.profile.institution.separate_allocation_requests %}
-                <h5> {% trans "System allocation requests" %}: </h5>
+                <h5> {% trans "Supercomputer access requests" %}: </h5>
                 {% endif %}
                 <table class="table table-bordered">
                     <tbody>
@@ -151,7 +151,7 @@
                     </tbody>
                 </table>
                 {% if request.user.profile.institution.allows_rse_requests %}
-                <h5> {% trans "RSE time allocation requests" %}: </h5>
+                <h5> {% trans "RSE support requests" %}: </h5>
                 <table class="table table-bordered">
                     <tbody>
                         <tr>
@@ -175,10 +175,10 @@
                 {% endif %}
             </div>
             {% if request.user.profile.institution.separate_allocation_requests %}
-            <a class='btn btn-primary' href="{% url 'create-allocation' project.pk %}">{% trans "New Allocation Request" %}</a>
+            <a class='btn btn-primary' href="{% url 'create-allocation' project.pk %}">{% trans "Request supercomputer usage" %}</a>
             {% endif %}
             {% if request.user.profile.institution.allows_rse_requests %}
-            <a class='btn btn-primary' href="{% url 'request-project-rse-time' project.pk %}">{% trans "New RSE time Request" %}</a>
+            <a class='btn btn-primary' href="{% url 'request-project-rse-time' project.pk %}">{% trans "Request RSE support" %}</a>
             {% endif %}
         </div>
     </div>

--- a/templates/project/rse_detail.html
+++ b/templates/project/rse_detail.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 {% load static %}
 {% load widget_tweaks %}
-{% block title %}{% trans "RSE time request details" %}{% endblock %}
+{% block title %}{% trans "RSE support request details" %}{% endblock %}
 {% block content %}
 	<div class="my-3 px-3 pt-3 bg-white rounded box-shadow">
 		<div class="row">
 			<div class="col">
 				<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
-					<h4>{% trans "RSE time request details" %}</h4>
+					<h4>{% trans "RSE support request details" %}</h4>
 				</div>
 			</div>
 		</div>

--- a/templates/project/rse_time.html
+++ b/templates/project/rse_time.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 {% load static %}
 {% load widget_tweaks %}
-{% block title %}{% trans "RSE Time Application" %}{% endblock %}
+{% block title %}{% trans "RSE Support Application" %}{% endblock %}
 {% block content %}
 	<div class="my-3 p-3 bg-white rounded box-shadow">
 		<div class="row">
 			<div class="col">
 				<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
-					<h4>{% trans "RSE Time Application" %}</h4>
+					<h4>{% trans "RSE Support Application" %}</h4>
 				</div>
 				<form method="post" enctype="multipart/form-data" novalidate>
 					{% csrf_token %}


### PR DESCRIPTION
Not immediately clear to a new user what a "systems allocation request" or "RSE time request" is; this renames them to "Supercomputer access request" and "RSE support request"