### PR TITLE
use on-disk db if using --keepdb

### DIFF
--- a/cogs3/settings.py
+++ b/cogs3/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 
 import ast
 import os
+import sys
 
 import dj_database_url
 from django.contrib.messages import constants as messages
@@ -132,8 +133,15 @@ DATABASES = {
     'default': dj_database_url.config(
         default='sqlite:///' + os.path.join(BASE_DIR, 'db.sqlite3'),
         conn_max_age=500,
-    )
+    ),
 }
+
+if 'test' in sys.argv and '--keepdb' in sys.argv:
+    # Persist test db to disk to avoid reapplying migrations every time
+    DATABASES['default']['TEST'] = dj_database_url.config(
+        default='sqlite:///' + os.path.join(BASE_DIR, 'test_db.sqlite3'),
+        conn_max_age=500,
+    )
 
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
the `--keepdb` option to `manage.py test` allows the test database to be persisted between test runs, provided that the database exists outside of memory. this PR changes `settings.py` so that if the test suite is being run with `--keepdb`, then the database is placed on disk to allow this to happen.