### PR TITLE
write minimal tests for ListFundingSourceMemberships view

### DIFF
--- a/funding/fixtures/tests/funding_source_memberships.json
+++ b/funding/fixtures/tests/funding_source_memberships.json
@@ -1,0 +1,46 @@
+[
+   {
+      "fields" : {
+         "created_time" : "2018-04-16T12:00:28Z",
+         "modified_time" : "2018-04-16T12:00:28Z",
+         "fundingsource" : 1,
+         "user" : 1,
+         "approved" : true
+      },
+      "model" : "funding.fundingsourcemembership",
+      "pk" : 1
+   },
+   {
+      "fields" : {
+         "created_time" : "2018-04-16T12:00:28Z",
+         "modified_time" : "2018-04-16T12:00:28Z",
+         "fundingsource" : 1,
+         "user" : 5,
+         "approved" : true
+      },
+      "model" : "funding.fundingsourcemembership",
+      "pk" : 2
+   },
+   {
+      "fields" : {
+         "created_time" : "2018-04-16T12:00:28Z",
+         "modified_time" : "2018-04-16T12:00:28Z",
+         "fundingsource" : 1,
+         "user" : 4,
+         "approved" : false
+      },
+      "model" : "funding.fundingsourcemembership",
+      "pk" : 3
+   },
+   {
+      "fields" : {
+         "created_time" : "2018-04-16T12:00:28Z",
+         "modified_time" : "2018-04-16T12:00:28Z",
+         "fundingsource" : 1,
+         "user" : 7,
+         "approved" : true
+      },
+      "model" : "funding.fundingsourcemembership",
+      "pk" : 4
+   }
+]

--- a/funding/tests/test_views.py
+++ b/funding/tests/test_views.py
@@ -801,3 +801,31 @@ class FundingSourceDeleteViewTests(FundingViewTests, TestCase):
                 args=[funding_source.id]
             )
         )
+
+
+class ListFundingSourceMembershipTests(FundingViewTests, TestCase):
+    def test_access_as_unauthorised_user(self):
+        """
+        Ensure that users not logged in get booted out of this page
+        """
+        self.access_view_as_unauthorised_user(
+            reverse('list-funding_source_memberships')
+        )
+
+    def test_access_as_authorised_user(self):
+        """
+        Check that logged in users can see this page.
+        """
+        user = CustomUser.objects.get(email="shibboleth.user@example.ac.uk")
+        institution = Institution.objects.get(name="Example University")
+        headers = {
+            'Shib-Identity-Provider': institution.identity_provider,
+            'REMOTE_USER': user.email,
+        }
+
+        response = self.client.get(
+            reverse('list-funding_source_memberships'),
+            **headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test funding source")

--- a/funding/tests/test_views.py
+++ b/funding/tests/test_views.py
@@ -8,6 +8,8 @@ from funding.views import FundingSourceAddView
 from funding.views import FundingSourceCreateView
 from funding.views import PublicationCreateView
 from funding.views import AttributionListView
+from funding.views import FundingSourceListView
+from funding.views import PublicationListView
 from funding.views import AttributionUpdateView
 from funding.views import AttributioneDeleteView
 from users.models import CustomUser
@@ -265,6 +267,8 @@ class FundingSourceAddViewTests(FundingViewTests, TestCase):
 
 
 class AttributionListViewTests(FundingViewTests, TestCase):
+    view = AttributionListView
+    view_name = 'list-attributions'
 
     def test_view_as_an_authorised_user(self):
         """
@@ -290,19 +294,29 @@ class AttributionListViewTests(FundingViewTests, TestCase):
                 'REMOTE_USER': account.get('email'),
             }
             response = self.client.get(
-                reverse('list-attributions'),
+                reverse(self.view_name),
                 **headers
             )
             self.assertEqual(response.status_code,
                              account.get('expected_status_code'))
             self.assertTrue(isinstance(response.context_data.get('view'),
-                                       AttributionListView))
+                                       self.view))
 
     def test_view_as_an_unauthorised_user(self):
         """
-        Ensure unauthorised users can not access the project create view.
+        Ensure unauthorised users can not access the attribution list view.
         """
-        self.access_view_as_unauthorised_user(reverse('list-attributions'))
+        self.access_view_as_unauthorised_user(reverse(self.view_name))
+
+
+class FundingSourceListViewTests(AttributionListViewTests):
+    view = FundingSourceListView
+    view_name = 'list-funding_sources'
+
+
+class PublicationListViewTests(AttributionListViewTests):
+    view = PublicationListView
+    view_name = 'list-publications'
 
 
 class FundingSourceUpdateViewTests(FundingViewTests, TestCase):

--- a/funding/views.py
+++ b/funding/views.py
@@ -285,7 +285,11 @@ class FundingsourceDetailView(LoginRequiredMixin, generic.DetailView):
     model = FundingSource
 
     def user_passes_test(self, request):
-        return FundingSource.objects.filter(id=self.kwargs['pk'], users=self.request.user).exists()
+        return FundingSourceMembership.objects.filter(
+            fundingsource=FundingSource.objects.get(id=self.kwargs['pk']),
+            user=self.request.user,
+            approved=True
+        ).exists()
 
     def dispatch(self, request, *args, **kwargs):
         if not self.user_passes_test(request):


### PR DESCRIPTION
fixes edbennett#126

the view is actually not very well named; you're not viewing your memberships of funding source, you're viewing others' memberships (or requests for such) of your funding sources.

builds on #23, since I needed the funding source membership fixtures here too.